### PR TITLE
Fix PhotoView dependency coordinates

### DIFF
--- a/Insurance/build.gradle.kts
+++ b/Insurance/build.gradle.kts
@@ -87,7 +87,7 @@ dependencies {
 
     // PDF Viewer
 
-    implementation("io.github.chrisbanes:PhotoView:2.3.0")
+    implementation("com.github.chrisbanes:PhotoView:2.3.0")
 
 
 


### PR DESCRIPTION
## Summary
- update the PhotoView dependency in Insurance/build.gradle.kts to use the correct Maven coordinates so Gradle can resolve it

## Testing
- `./gradlew :app:mergeDebugNativeLibs` *(fails: proxy blocked Gradle distribution download)*

------
https://chatgpt.com/codex/tasks/task_e_68d433761018832aa511611a94fb9556