### PR TITLE
Add JitPack repository for PhotoView dependency

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,8 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        // Required for dependencies hosted on JitPack (e.g. PhotoView)
+        maven("https://jitpack.io")
         jcenter()//PDF Viewer
     }
 }


### PR DESCRIPTION
## Summary
- add the JitPack Maven repository to resolve the PhotoView dependency

## Testing
- unable to run `./gradlew :Insurance:assembleDebug` due to Gradle distribution download being blocked by the environment proxy

------
https://chatgpt.com/codex/tasks/task_e_68d434348a88832aa8ef8aa14c585431