### PR TITLE
Adjust Android JDK image transform override

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,9 @@ android.nonTransitiveRClass=true
 
 #add to pdf viewer
 android.enableJetifier=true
+
+# Disable the Android JDK image transform because running jlink fails on some
+# environments (for example, Windows installations where the tool cannot create
+# the trimmed JDK image). Falling back to the untrimmed JDK avoids the transform
+# and lets the build continue.
+android.experimental.jdkImageTransformOptions=useFullJdk

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,8 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        // Required for dependencies hosted on JitPack (e.g. PhotoView)
+        maven("https://jitpack.io")
         jcenter()//PDF Viewer
     }
 }


### PR DESCRIPTION
## Summary
- switch the JDK image transform override to use the full, untrimmed JDK so the build never invokes jlink
- keep the documentation in gradle.properties explaining why the override is necessary

## Testing
- unable to run `./gradlew :Insurance:assembleDebug` because downloading the Gradle distribution is blocked by the environment proxy


------
https://chatgpt.com/codex/tasks/task_e_68d434348a88832aa8ef8aa14c585431