### PR TITLE
Clarify JDK transform workaround

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,8 +27,8 @@ android.enableJetifier=true
 
 # Disable the Android JDK image transform because running jlink fails on some
 # environments (for example, Windows installations where the tool cannot create
-
-# the trimmed JDK image). Falling back to the untrimmed JDK avoids the transform
-# and lets the build continue.
+# the trimmed JDK image and reports a failure while transforming
+# core-for-system-modules.jar). Falling back to the untrimmed JDK avoids the
+# transform and lets the build continue.
 android.experimental.jdkImageTransformOptions=useFullJdk
 


### PR DESCRIPTION
## Summary
- explain why the `android.experimental.jdkImageTransformOptions=useFullJdk` override is in place
- document that it specifically addresses the `core-for-system-modules.jar` jlink failure seen on some Windows setups

## Testing
- not run (network restrictions prevented downloading the Gradle distribution)


------
https://chatgpt.com/codex/tasks/task_e_68d444bd8390832aa80e4c4a2fe6d401