### PR TITLE
Make delete account menu item less prominent

### DIFF
--- a/app/src/main/res/menu/activity_main_drawer_custom.xml
+++ b/app/src/main/res/menu/activity_main_drawer_custom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:showIn="navigation_view">
 
@@ -53,7 +54,8 @@
                 <item
                     android:id="@+id/nav_delete_account"
                     android:icon="@drawable/ic_person_off"
-                    android:title="@string/menu_delete_account"/>
+                    android:title="@string/menu_delete_account_discreet"
+                    app:iconTint="@color/color_text_delete_account_discreet"/>
             </menu>
         </item>
 


### PR DESCRIPTION
## Summary
- adjust the delete account entry in the custom navigation drawer to use the discreet gray label
- tint the delete account icon gray to match the lower-visibility styling

## Testing
- :x: `./gradlew :app:lint` *(fails: Unable to tunnel through proxy while downloading Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d450611148832a96d022e36f5873ac