### PR TITLE
Disable release minification to fix AAB build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,7 +32,10 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            // Deshabilitamos R8 para el release porque la ofuscación estaba generando
+            // errores de clases faltantes durante el empaquetado del .aab. Con el shrink
+            // desactivado evitamos que se ejecute R8 y el bundle se genera correctamente.
+            isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"


### PR DESCRIPTION
## Summary
- disable minification for the release build type so R8 no longer runs during bundle generation
- add inline comment documenting that this avoids the missing class errors raised when building the AAB

## Testing
- gradle :app:bundleRelease *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d570715830832a818dc725329c7599